### PR TITLE
Fix shebang declaration in getMesosStats.py

### DIFF
--- a/getMesosStats.py
+++ b/getMesosStats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import urllib2


### PR DESCRIPTION
Hi, @zolech.

Thank you for your work. You saved me a lot of time by giving these Zabbix templates for Mesos Agent and Mesos Master.

I found that your python script `getMesosStats.py` uses incorrect form of path to executable python program. In fact, in the variety of operating systems path may differ. The best option to handle it is to use `env` utility which is always here: `/usr/bin/env`.