### PR TITLE
Fix KeyError exception for non-existing keys

### DIFF
--- a/getMesosStats.py
+++ b/getMesosStats.py
@@ -8,7 +8,8 @@ import argparse
 
 def get_metric(host, port, metric):
         response = urllib2.urlopen(
-            'http://' + host + ':' + port + '/metrics/snapshot')
+            'http://{host}:{port}/metrics/snapshot'.format(host=host, port=port)
+        )
         data = json.load(response)
         # print json.dumps(data, indent=4, sort_keys=True)
         try:

--- a/getMesosStats.py
+++ b/getMesosStats.py
@@ -11,7 +11,10 @@ def get_metric(host, port, metric):
             'http://' + host + ':' + port + '/metrics/snapshot')
         data = json.load(response)
         # print json.dumps(data, indent=4, sort_keys=True)
-        print data[metric]
+        try:
+            print data[metric]
+        except KeyError:
+            print "ZBX_NOT_SUPPORTED"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I also found a few minor mistakes and made a quick fix:

1) The more pythonic way to concatenate two or more strings is to use strings interpolations. I am not a Python expert, but it looks better for me.
2) Forgotten `KeyError` exception in case metric does not exist in JSON. According to Zabbix documentation, `ZBX_NOT_SUPPORTED` response is suitable to tell Zabbix Server that item is not supported by Agent.

